### PR TITLE
Fixes from go-staticcheck lints

### DIFF
--- a/controllers/v1/callback.go
+++ b/controllers/v1/callback.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -136,7 +136,7 @@ func GetCallback(c *gin.Context) {
 			return
 		}
 		defer request.Body.Close()
-		body, err := ioutil.ReadAll(request.Body)
+		body, err := io.ReadAll(request.Body)
 		if err != nil {
 			result <- Result{err: err}
 			return
@@ -172,7 +172,7 @@ func GetCallback(c *gin.Context) {
 		}
 		defer userResponse.Body.Close()
 
-		userBody, err := ioutil.ReadAll(userResponse.Body)
+		userBody, err := io.ReadAll(userResponse.Body)
 		if err != nil {
 			result <- Result{err: err}
 			return

--- a/controllers/v1/certs.go
+++ b/controllers/v1/certs.go
@@ -28,11 +28,6 @@ import (
 	"hawton.dev/log4g"
 )
 
-type certReturn struct {
-	message string
-	keys    jwk.Set
-}
-
 func GetCerts(c *gin.Context) {
 	jkeyset := os.Getenv("SSO_JWKS")
 	keyset, err := jwk.Parse([]byte(jkeyset))

--- a/database/models/main.go
+++ b/database/models/main.go
@@ -32,15 +32,11 @@ import (
 	"github.com/imdario/mergo"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
-	"hawton.dev/log4g"
 )
 
 var DB *gorm.DB
 var MaxAttempts = 10
 var DelayBetweenAttempts = time.Minute * 1
-var attempt = 1
-
-var log = log4g.Category("db")
 
 type DBOptions struct {
 	Driver   string

--- a/middleware/jwt/jwt.go
+++ b/middleware/jwt/jwt.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	ErrNoToken = errors.New("No Token Specified")
+	ErrNoToken = errors.New("no token specified")
 )
 
 var requireAuth bool

--- a/pkg/pkce/pkce.go
+++ b/pkg/pkce/pkce.go
@@ -7,10 +7,5 @@ import (
 
 func VerifyCodeVerifierS256(codeChallenge, codeVerifier string) bool {
 	hash := sha256.Sum256([]byte(codeVerifier))
-
-	if codeChallenge != base64.RawURLEncoding.EncodeToString(hash[:]) {
-		return false
-	}
-
-	return true
+	return codeChallenge == base64.RawURLEncoding.EncodeToString(hash[:])
 }


### PR DESCRIPTION
There's 1 more unresolved lint [here](https://github.com/adh-partnership/auth/blob/df0fe4b3ea4bdaaffaee9afd1027a7f84877524e/controllers/v1/token.go#L150) about that variable possibly being nil.